### PR TITLE
Battery optimization and sound toggle feature

### DIFF
--- a/components/audio_hal/include/audio_hal.h
+++ b/components/audio_hal/include/audio_hal.h
@@ -65,6 +65,12 @@ uint8_t *audio_get_sound_registers(void);
  */
 void audio_set_power_state(bool enabled);
 
+/**
+ * Toggle audio mute on/off
+ * @return true if now muted, false if now unmuted
+ */
+bool audio_toggle_mute(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/audio_hal/src/audio_hal.cpp
+++ b/components/audio_hal/src/audio_hal.cpp
@@ -239,3 +239,24 @@ void audio_set_power_state(bool enabled)
         ESP_LOGI(TAG, "Audio amplifier disabled (silence detected)");
     }
 }
+
+// Mute state for user-toggled mute
+static bool audio_muted = false;
+
+bool audio_toggle_mute(void)
+{
+    audio_muted = !audio_muted;
+    
+    if (audio_muted) {
+        // Mute by setting DAC volume to 0
+        es8311_write_reg(ES8311_REG_DAC_VOL, 0x00);
+        ESP_LOGI(TAG, "Audio muted");
+    } else {
+        // Unmute by restoring DAC volume
+        es8311_write_reg(ES8311_REG_DAC_VOL, 0xBF);
+        ESP_LOGI(TAG, "Audio unmuted");
+    }
+    
+    return audio_muted;
+}
+

--- a/components/display/include/display.h
+++ b/components/display/include/display.h
@@ -83,8 +83,8 @@ void display_fill(uint16_t color);
 void display_set_backlight(uint8_t brightness);
 
 // Brightness levels for adaptive power management
-#define DISPLAY_BRIGHTNESS_ACTIVE  153  // 60% for active gameplay
-#define DISPLAY_BRIGHTNESS_IDLE    77   // 30% for idle/attract mode
+#define DISPLAY_BRIGHTNESS_ACTIVE  128  // 50% for active gameplay and video
+#define DISPLAY_BRIGHTNESS_IDLE    64   // 25% for idle/attract mode
 
 #ifdef __cplusplus
 }

--- a/main/src/main.cpp
+++ b/main/src/main.cpp
@@ -151,12 +151,12 @@ extern "C" void app_main(void) {
       if (current_brightness != DISPLAY_BRIGHTNESS_IDLE) {
         display_set_backlight(DISPLAY_BRIGHTNESS_IDLE);
         current_brightness = DISPLAY_BRIGHTNESS_IDLE;
-        ESP_LOGI(TAG, "Backlight dimmed to 30%% (idle)");
+        ESP_LOGI(TAG, "Backlight dimmed to 25%% (idle)");
       }
     } else if (current_brightness != DISPLAY_BRIGHTNESS_ACTIVE) {
       display_set_backlight(DISPLAY_BRIGHTNESS_ACTIVE);
       current_brightness = DISPLAY_BRIGHTNESS_ACTIVE;
-      ESP_LOGI(TAG, "Backlight restored to 60%% (active)");
+      ESP_LOGI(TAG, "Backlight restored to 50%% (active)");
     }
 
     // 7. Trigger VBLANK interrupt if enabled


### PR DESCRIPTION
## Summary
- Reduce active brightness from 60% to 50%
- Reduce idle brightness from 30% to 25%  
- Add BOOT button long-press (~1s) to toggle sound on/off
- PWR button long-press still powers off device

## Changes
- `display.h`: Updated brightness constants (50%/25%)
- `main.cpp`: Updated log messages
- `audio_hal.h/cpp`: Added `audio_toggle_mute()` function
- `pacman_input.cpp`: Added BOOT long-press detection for sound toggle

## Testing
- Build verification needed
- Flash device and test:
  - Short-press BOOT: coin/start
  - Long-press BOOT (~1s): toggle sound
  - Long-press PWR (~1s): power off